### PR TITLE
ログ出力内の作成した issue の URL を修正

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,4 @@
 dist/
-lib/
 node_modules/
-jest.config.js
+
 src/graphql/index.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,3 @@
 dist/
-lib/
 node_modules/
 src/graphql/index.ts

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -28,7 +28,7 @@ export class ApiClient {
     originalIssue: Issue,
     repository: Repository
   ): Promise<{
-    readonly node_id: string
+    readonly id: string
     readonly url: string
   }> {
     // https://docs.github.com/en/rest/issues/issues#create-an-issue
@@ -41,13 +41,11 @@ export class ApiClient {
       labels: originalIssue.labels,
       assignees: originalIssue.assignees.map(({login}) => login)
     })
-    return {node_id: createdIssue.node_id, url: createdIssue.html_url}
+    return {id: createdIssue.node_id, url: createdIssue.html_url}
   }
 
-  async getProjectFieldValues(
-    issueNodeId: string
-  ): Promise<readonly Project[]> {
-    const data = await this.graphql.projectFieldValues({issueNodeId})
+  async getProjectFieldValues(issueId: string): Promise<readonly Project[]> {
+    const data = await this.graphql.projectFieldValues({issueId})
     if (!(data.node && 'projectItems' in data.node)) {
       throw new Error('Missing `projectItems` for the original issue.')
     }
@@ -85,12 +83,9 @@ export class ApiClient {
       }))
   }
 
-  async addIssueToProject(
-    issueNodeId: string,
-    projectId: string
-  ): Promise<string> {
+  async addIssueToProject(issueId: string, projectId: string): Promise<string> {
     const data = await this.graphql.addIssueToProject({
-      input: {projectId, contentId: issueNodeId}
+      input: {projectId, contentId: issueId}
     })
     const itemId = data.addProjectV2ItemById?.item?.id
     if (!itemId) throw new Error('Missing itemId.')

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -41,7 +41,7 @@ export class ApiClient {
       labels: originalIssue.labels,
       assignees: originalIssue.assignees.map(({login}) => login)
     })
-    return createdIssue
+    return {node_id: createdIssue.node_id, url: createdIssue.html_url}
   }
 
   async getProjectFieldValues(

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -1,5 +1,5 @@
 import * as github from '@actions/github'
-import {Issue, Repository} from '@octokit/webhooks-types'
+import type {Issue, Repository} from '@octokit/webhooks-types'
 import {ProjectV2FieldValue, Sdk, getSdk} from './graphql'
 
 type Field = {

--- a/src/graphql/projectFieldValues.graphql
+++ b/src/graphql/projectFieldValues.graphql
@@ -1,5 +1,5 @@
-query projectFieldValues($issueNodeId: ID!) {
-  node(id: $issueNodeId) {
+query projectFieldValues($issueId: ID!) {
+  node(id: $issueId) {
     ... on Issue {
       projectItems(first: 10, includeArchived: false) {
         nodes {

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,10 +30,7 @@ async function duplicateIssueWithProjectFields(
 
   const projects = await apiClient.getProjectFieldValues(event.issue.node_id)
   for (const project of projects) {
-    const itemId = await apiClient.addIssueToProject(
-      newIssue.node_id,
-      project.id
-    )
+    const itemId = await apiClient.addIssueToProject(newIssue.id, project.id)
     core.info(`Added issue to project: ${project.url}`)
     core.debug(`itemId: ${itemId}`)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,7 @@ import * as core from '@actions/core'
 import * as github from '@actions/github'
 import {ApiClient} from './api-client'
 import {Context} from '@actions/github/lib/context'
-// eslint-disable-next-line import/no-unresolved
-import {IssueCommentEvent} from '@octokit/webhooks-types'
+import type {IssueCommentEvent} from '@octokit/webhooks-types'
 
 function filterDuplicateCommandEvent(
   context: Context

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ async function duplicateIssueWithProjectFields(
   apiClient: ApiClient,
   event: IssueCommentEvent
 ): Promise<void> {
+  core.info(`Original issue: ${event.issue.html_url}`)
   const newIssue = await apiClient.duplicateIssue(event.issue, event.repository)
   core.info(`Issue created: ${newIssue.url}`)
   core.debug('newIssue:')


### PR DESCRIPTION
[issue 作成 API](https://docs.github.com/en/rest/issues/issues#create-an-issue) のレスポンスに含まれる `url` を使っていたが、これは

```
https://api.github.com/repos/mashabow/issue-duplicator-action-test/issues/1
```

のような値であるため、クリックしてもブラウザ上で詳細が閲覧できない。

<img width="809" alt="動作確認用_·_mashabow_issue-duplicator-action-test_a54ed61" src="https://user-images.githubusercontent.com/6268183/204142073-dd523272-bc21-4166-aef4-8147881ad21f.png">

そこで代わりに `html_url` の方を使うようにする。

```
https://github.com/mashabow/issue-duplicator-action-test/issues/1
```

その他、細かなリファクタリングなど。