### PR TITLE
ソースマップの出力をやめる

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "scripts": {
-    "build": "npm run codegen && ncc build src/main.ts --source-map --license licenses.txt",
+    "build": "npm run codegen && ncc build src/main.ts --license licenses.txt",
     "format": "prettier --write '**/*.ts'",
     "format-check": "prettier --check '**/*.ts'",
     "lint": "eslint src/**/*.ts",


### PR DESCRIPTION
ソースマップの出力が有効になっていると、ビルド時に以下の3ファイルが出力される。

- `dist/index.js`
- `dist/index.js.map`
- `dist/sourcemap-register.js`

しかし、リリース時には https://github.com/JasonEtco/build-and-tag-action によって `dist/index.js` のみになるので、これを実行すると `dist/sourcemap-register.js` が読み込めずにエラーになる。

https://github.com/mashabow/issue-duplicator-action/issues/17#issuecomment-1328272167

そこで、最初からソースマップを出力しないようにして、この問題を回避する。