### PR TITLE
issue コメント編集によって `/duplicate` になった場合にも複製を実行する

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ name: Issue Duplicator
 
 on:
   issue_comment:
-    types: [created]
+    types: [created, edited]
 
 jobs:
   run:
@@ -52,7 +52,7 @@ name: Issue Duplicator (dev)
 
 on:
   issue_comment:
-    types: [created]
+    types: [created, edited]
 
 jobs:
   run:

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,8 +14,10 @@ function filterDuplicateCommandEvent(
   }
 
   const event = context.payload as IssueCommentEvent
-  if (event.action !== 'created') {
-    throw new Error('This action must be used with `created` activity type.')
+  if (!['created', 'edited'].includes(event.action)) {
+    throw new Error(
+      'This action must be used with `created` or `edited` activity type.'
+    )
   }
 
   return event.comment.body.trim() === COMMAND ? event : null


### PR DESCRIPTION
## 動作確認

`hoge` を編集して `/duplicate` に変更したら複製された ✅

<img width="1306" alt="てすと_·_Issue__3_·_mashabow_issue-duplicator-action-test" src="https://user-images.githubusercontent.com/6268183/204816902-2405fb2c-bf44-47df-82ee-a8005ec500a0.png">